### PR TITLE
Add agency balance updates from detail view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+uploads/logos/*
+!uploads/logos/.gitkeep

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# ajans1
+# Ajans Giriş Sistemi
+
+Bu proje, Yazılım Ustası sistemine ajansların kayıt olup yönetici onayıyla giriş yapabilmesi için oluşturulmuş basit bir PHP uygulamasıdır.
+
+## Kurulum
+
+1. `config.php` içindeki veritabanı ayarlarını düzenleyin.
+2. `database.sql` dosyasını veritabanınıza aktararak gerekli tabloları ve örnek kayıtları oluşturun.
+3. `uploads/logos` klasörünün yazılabilir olduğundan emin olun.
+4. `index.php` üzerinden giriş yapabilir veya `register.php` ile yeni ajans hesabı oluşturabilirsiniz.
+5. Yönetici girişi için `admin/login.php` sayfasını kullanın.
+6. Admin panelinde anasayfa, ajans listesi ve ayarlar menülerine erişebilirsiniz.
+
+### Örnek Hesaplar
+
+- Yönetici: `admin@example.com` / `admin123`
+- Ajans: `demo@agency.com` / `agency123`
+
+Logo ve boyut ayarlarını değiştirmek için yönetici panelindeki `Ayarlar` sayfasını kullanabilirsiniz.
+`Ajanslar` menüsünden kayıtlı ajansları görüntüleyebilir, onaylayabilir ve düzenleyebilirsiniz. Ajans detaylarında sipariş listesini görebilir ve siparişlere geçiş yapabilirsiniz.

--- a/admin/agencies.php
+++ b/admin/agencies.php
@@ -1,0 +1,59 @@
+<?php
+require_once '../config.php';
+if (!isset($_SESSION['admin_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+if (isset($_POST['action'], $_POST['id'])) {
+    $id = (int)$_POST['id'];
+    if ($_POST['action'] === 'approve') {
+        $stmt = $pdo->prepare('UPDATE agencies SET status = "active" WHERE id = ?');
+        $stmt->execute([$id]);
+    } elseif ($_POST['action'] === 'reject') {
+        $stmt = $pdo->prepare('UPDATE agencies SET status = "rejected" WHERE id = ?');
+        $stmt->execute([$id]);
+    }
+}
+
+$agencies = $pdo->query('SELECT * FROM agencies ORDER BY created_at DESC')->fetchAll();
+?>
+<?php include 'partials/header.php'; ?>
+<h2>Ajanslar</h2>
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Ajans Adı</th>
+            <th>E-posta</th>
+            <th>Yetkili</th>
+            <th>Telefon</th>
+            <th>Bakiye</th>
+            <th>Durum</th>
+            <th>İşlemler</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($agencies as $agency): ?>
+        <tr>
+            <td><?php echo htmlspecialchars($agency['agency_name']); ?></td>
+            <td><?php echo htmlspecialchars($agency['email']); ?></td>
+            <td><?php echo htmlspecialchars($agency['contact_name']); ?></td>
+            <td><?php echo htmlspecialchars($agency['phone']); ?></td>
+            <td><?php echo number_format($agency['balance'],2); ?> ₺</td>
+            <td><?php echo htmlspecialchars($agency['status']); ?></td>
+            <td>
+                <?php if ($agency['status'] === 'pending'): ?>
+                    <form method="post" class="d-inline">
+                        <input type="hidden" name="id" value="<?php echo $agency['id']; ?>">
+                        <input type="hidden" name="action" value="approve">
+                        <button class="btn btn-success btn-sm">Onayla</button>
+                    </form>
+                <?php endif; ?>
+                <a href="edit_agency.php?id=<?php echo $agency['id']; ?>" class="btn btn-primary btn-sm ms-1">Düzenle</a>
+                <a href="agency_details.php?id=<?php echo $agency['id']; ?>" class="btn btn-secondary btn-sm ms-1">Detay</a>
+            </td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<?php include 'partials/footer.php'; ?>

--- a/admin/agency_details.php
+++ b/admin/agency_details.php
@@ -1,0 +1,73 @@
+<?php
+require_once '../config.php';
+if (!isset($_SESSION['admin_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+$id = (int)($_GET['id'] ?? 0);
+$agencyStmt = $pdo->prepare('SELECT * FROM agencies WHERE id=?');
+$agencyStmt->execute([$id]);
+$agency = $agencyStmt->fetch();
+if (!$agency) {
+    echo 'Ajans bulunamadı';
+    exit;
+}
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['amount'])) {
+    $amount = (float)$_POST['amount'];
+    $stmt = $pdo->prepare('UPDATE agencies SET balance = balance + ? WHERE id=?');
+    $stmt->execute([$amount, $id]);
+    $message = 'Bakiye güncellendi';
+    $agencyStmt->execute([$id]);
+    $agency = $agencyStmt->fetch();
+}
+
+$orders = $pdo->prepare('SELECT * FROM orders WHERE agency_id=? ORDER BY created_at DESC');
+$orders->execute([$id]);
+$orders = $orders->fetchAll();
+?>
+<?php include 'partials/header.php'; ?>
+<h2>Ajans Detayları</h2>
+<?php if ($message): ?>
+    <div class="alert alert-success"><?php echo htmlspecialchars($message); ?></div>
+<?php endif; ?>
+<ul class="list-group mb-4">
+    <li class="list-group-item"><strong>Ajans:</strong> <?php echo htmlspecialchars($agency['agency_name']); ?></li>
+    <li class="list-group-item"><strong>E-posta:</strong> <?php echo htmlspecialchars($agency['email']); ?></li>
+    <li class="list-group-item"><strong>Yetkili:</strong> <?php echo htmlspecialchars($agency['contact_name']); ?></li>
+    <li class="list-group-item"><strong>Telefon:</strong> <?php echo htmlspecialchars($agency['phone']); ?></li>
+    <li class="list-group-item"><strong>Bakiye:</strong> <?php echo number_format($agency['balance'],2); ?> ₺</li>
+    <li class="list-group-item"><strong>Durum:</strong> <?php echo htmlspecialchars($agency['status']); ?></li>
+</ul>
+<form method="post" class="mb-4">
+    <label class="form-label">Tahsilat Tutarı</label>
+    <div class="input-group">
+        <input type="number" step="0.01" name="amount" class="form-control" required>
+        <button class="btn btn-success" type="submit">Tahsilat Yap</button>
+    </div>
+</form>
+<h3>Siparişler</h3>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Sipariş Adı</th>
+            <th>Tutar</th>
+            <th>Tarih</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($orders as $order): ?>
+        <tr>
+            <td><?php echo htmlspecialchars($order['order_name']); ?></td>
+            <td><?php echo number_format($order['total'],2); ?> ₺</td>
+            <td><?php echo htmlspecialchars($order['created_at']); ?></td>
+            <td><a href="order_details.php?id=<?php echo $order['id']; ?>" class="btn btn-sm btn-outline-primary">Görüntüle</a></td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<a href="agencies.php" class="btn btn-secondary">Geri</a>
+<?php include 'partials/footer.php'; ?>

--- a/admin/agency_requests.php
+++ b/admin/agency_requests.php
@@ -1,0 +1,53 @@
+<?php
+require_once '../config.php';
+if (!isset($_SESSION['admin_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+if (isset($_POST['action'], $_POST['id'])) {
+    $id = (int)$_POST['id'];
+    if ($_POST['action'] === 'approve') {
+        $stmt = $pdo->prepare('UPDATE agencies SET status = "active" WHERE id = ?');
+    } else {
+        $stmt = $pdo->prepare('UPDATE agencies SET status = "rejected" WHERE id = ?');
+    }
+    $stmt->execute([$id]);
+}
+
+$pending = $pdo->query("SELECT * FROM agencies WHERE status = 'pending'")->fetchAll();
+?>
+<?php include 'partials/header.php'; ?>
+<h2>Bekleyen Ajans Kayıtları</h2>
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Ajans Adı</th>
+            <th>Yetkili</th>
+            <th>E-posta</th>
+            <th>İşlemler</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($pending as $agency): ?>
+            <tr>
+                <td><?php echo htmlspecialchars($agency['agency_name']); ?></td>
+                <td><?php echo htmlspecialchars($agency['contact_name']); ?></td>
+                <td><?php echo htmlspecialchars($agency['email']); ?></td>
+                <td>
+                    <form method="post" class="d-inline">
+                        <input type="hidden" name="id" value="<?php echo $agency['id']; ?>">
+                        <input type="hidden" name="action" value="approve">
+                        <button class="btn btn-success btn-sm">Onayla</button>
+                    </form>
+                    <form method="post" class="d-inline ms-2">
+                        <input type="hidden" name="id" value="<?php echo $agency['id']; ?>">
+                        <input type="hidden" name="action" value="reject">
+                        <button class="btn btn-danger btn-sm">Reddet</button>
+                    </form>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<?php include 'partials/footer.php'; ?>

--- a/admin/edit_agency.php
+++ b/admin/edit_agency.php
@@ -1,0 +1,73 @@
+<?php
+require_once '../config.php';
+if (!isset($_SESSION['admin_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+$id = (int)($_GET['id'] ?? 0);
+$agency = $pdo->prepare('SELECT * FROM agencies WHERE id = ?');
+$agency->execute([$id]);
+$agency = $agency->fetch();
+if (!$agency) {
+    echo 'Ajans bulunamadı';
+    exit;
+}
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $stmt = $pdo->prepare('UPDATE agencies SET agency_name=?, contact_name=?, phone=?, email=?, tax_number=?, tax_office=?, balance=? WHERE id=?');
+    $stmt->execute([
+        $_POST['agency_name'],
+        $_POST['contact_name'],
+        $_POST['phone'],
+        $_POST['email'],
+        $_POST['tax_number'],
+        $_POST['tax_office'],
+        $_POST['balance'],
+        $id
+    ]);
+    $message = 'Güncellendi';
+    $agency = $pdo->prepare('SELECT * FROM agencies WHERE id = ?');
+    $agency->execute([$id]);
+    $agency = $agency->fetch();
+}
+?>
+<?php include 'partials/header.php'; ?>
+<h2>Ajans Düzenle</h2>
+<?php if ($message): ?>
+    <div class="alert alert-success"><?php echo $message; ?></div>
+<?php endif; ?>
+<form method="post">
+    <div class="mb-3">
+        <label class="form-label">Ajans Adı</label>
+        <input type="text" name="agency_name" value="<?php echo htmlspecialchars($agency['agency_name']); ?>" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Yetkili Adı Soyadı</label>
+        <input type="text" name="contact_name" value="<?php echo htmlspecialchars($agency['contact_name']); ?>" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Telefon</label>
+        <input type="text" name="phone" value="<?php echo htmlspecialchars($agency['phone']); ?>" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">E-posta</label>
+        <input type="email" name="email" value="<?php echo htmlspecialchars($agency['email']); ?>" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Vergi Numarası</label>
+        <input type="text" name="tax_number" value="<?php echo htmlspecialchars($agency['tax_number']); ?>" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Vergi Dairesi</label>
+        <input type="text" name="tax_office" value="<?php echo htmlspecialchars($agency['tax_office']); ?>" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Bakiye</label>
+        <input type="number" step="0.01" name="balance" value="<?php echo htmlspecialchars($agency['balance']); ?>" class="form-control" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Kaydet</button>
+    <a href="agencies.php" class="btn btn-secondary">Geri</a>
+</form>
+<?php include 'partials/footer.php'; ?>

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,0 +1,11 @@
+<?php
+require_once '../config.php';
+if (!isset($_SESSION['admin_id'])) {
+    header('Location: login.php');
+    exit;
+}
+?>
+<?php include 'partials/header.php'; ?>
+<h2>Admin Anasayfa</h2>
+<p>Buradan ajansları yönetebilir ve ayarları düzenleyebilirsiniz.</p>
+<?php include 'partials/footer.php'; ?>

--- a/admin/login.php
+++ b/admin/login.php
@@ -1,0 +1,43 @@
+<?php
+require_once '../config.php';
+if (isset($_SESSION['admin_id'])) {
+    header('Location: agency_requests.php');
+    exit;
+}
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = $_POST['email'];
+    $password = $_POST['password'];
+    $stmt = $pdo->prepare('SELECT * FROM admins WHERE email = ?');
+    $stmt->execute([$email]);
+    $admin = $stmt->fetch();
+    if ($admin && password_verify($password, $admin['password_hash'])) {
+        $_SESSION['admin_id'] = $admin['id'];
+        header('Location: agency_requests.php');
+        exit;
+    } else {
+        $message = 'Geçersiz giriş.';
+    }
+}
+?>
+<?php include 'partials/header.php'; ?>
+<div class="row justify-content-center">
+    <div class="col-md-4">
+        <h2 class="mb-4 text-center text-white">Admin Girişi</h2>
+        <?php if ($message): ?>
+            <div class="alert alert-danger"><?php echo htmlspecialchars($message); ?></div>
+        <?php endif; ?>
+        <form method="post">
+            <div class="mb-3">
+                <label class="form-label text-white">E-posta</label>
+                <input type="email" name="email" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label text-white">Şifre</label>
+                <input type="password" name="password" class="form-control" required>
+            </div>
+            <button type="submit" class="btn btn-primary w-100">Giriş</button>
+        </form>
+    </div>
+</div>
+<?php include 'partials/footer.php'; ?>

--- a/admin/logout.php
+++ b/admin/logout.php
@@ -1,0 +1,5 @@
+<?php
+require_once '../config.php';
+unset($_SESSION['admin_id']);
+header('Location: login.php');
+exit;

--- a/admin/order_details.php
+++ b/admin/order_details.php
@@ -1,0 +1,25 @@
+<?php
+require_once '../config.php';
+if (!isset($_SESSION['admin_id'])) {
+    header('Location: login.php');
+    exit;
+}
+$id = (int)($_GET['id'] ?? 0);
+$stmt = $pdo->prepare('SELECT o.*, a.agency_name FROM orders o JOIN agencies a ON o.agency_id=a.id WHERE o.id=?');
+$stmt->execute([$id]);
+$order = $stmt->fetch();
+if (!$order) {
+    echo 'Sipariş bulunamadı';
+    exit;
+}
+?>
+<?php include 'partials/header.php'; ?>
+<h2>Sipariş Detayı</h2>
+<ul class="list-group mb-4">
+    <li class="list-group-item"><strong>Ajans:</strong> <?php echo htmlspecialchars($order['agency_name']); ?></li>
+    <li class="list-group-item"><strong>Sipariş Adı:</strong> <?php echo htmlspecialchars($order['order_name']); ?></li>
+    <li class="list-group-item"><strong>Tutar:</strong> <?php echo number_format($order['total'],2); ?> ₺</li>
+    <li class="list-group-item"><strong>Tarih:</strong> <?php echo htmlspecialchars($order['created_at']); ?></li>
+</ul>
+<a href="agency_details.php?id=<?php echo $order['agency_id']; ?>" class="btn btn-secondary">Geri</a>
+<?php include 'partials/footer.php'; ?>

--- a/admin/partials/footer.php
+++ b/admin/partials/footer.php
@@ -1,0 +1,4 @@
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/admin/partials/header.php
+++ b/admin/partials/header.php
@@ -1,0 +1,33 @@
+<?php
+require_once __DIR__.'/../../config.php';
+$s = $pdo->query('SELECT logo_url, logo_width, logo_height FROM settings LIMIT 1')->fetch();
+$logoUrl = $s['logo_url'] ?? '../uploads/logo.png';
+$logoW = $s['logo_width'] ?? 30;
+$logoH = $s['logo_height'] ?? 30;
+?>
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin Paneli</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-dark bg-dark mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="index.php">
+            <img src="../<?php echo htmlspecialchars($logoUrl); ?>" alt="Logo" width="<?php echo (int)$logoW; ?>" height="<?php echo (int)$logoH; ?>" class="me-2">
+            Admin Paneli
+        </a>
+        <?php if(isset($_SESSION['admin_id'])): ?>
+        <div class="d-flex">
+            <a href="index.php" class="btn btn-sm btn-outline-light me-2">Anasayfa</a>
+            <a href="agencies.php" class="btn btn-sm btn-outline-light me-2">Ajanslar</a>
+            <a href="settings.php" class="btn btn-sm btn-outline-light me-2">Ayarlar</a>
+            <a href="logout.php" class="btn btn-sm btn-outline-light">Çıkış</a>
+        </div>
+        <?php endif; ?>
+    </div>
+</nav>
+<div class="container">

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -1,0 +1,57 @@
+<?php
+require_once '../config.php';
+if (!isset($_SESSION['admin_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+$settings = $pdo->query('SELECT * FROM settings LIMIT 1')->fetch();
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $logo_width = (int)$_POST['logo_width'];
+    $logo_height = (int)$_POST['logo_height'];
+    $logo_path = $settings['logo_url'];
+
+    if (!empty($_FILES['logo']['name'])) {
+        $targetDir = '../uploads/';
+        if (!is_dir($targetDir)) {
+            mkdir($targetDir, 0777, true);
+        }
+        $fileName = uniqid() . '_' . basename($_FILES['logo']['name']);
+        $targetFile = $targetDir . $fileName;
+        if (move_uploaded_file($_FILES['logo']['tmp_name'], $targetFile)) {
+            $logo_path = 'uploads/' . $fileName;
+        }
+    }
+
+    $stmt = $pdo->prepare('UPDATE settings SET logo_url = ?, logo_width = ?, logo_height = ? WHERE id = ?');
+    $stmt->execute([$logo_path, $logo_width, $logo_height, $settings['id']]);
+    $message = 'Ayarlar güncellendi';
+    $settings = ['id'=>$settings['id'],'logo_url'=>$logo_path,'logo_width'=>$logo_width,'logo_height'=>$logo_height];
+}
+?>
+<?php include 'partials/header.php'; ?>
+<h2>Ayarlar</h2>
+<?php if ($message): ?>
+    <div class="alert alert-success"><?php echo htmlspecialchars($message); ?></div>
+<?php endif; ?>
+<form method="post" enctype="multipart/form-data" class="mb-4">
+    <div class="mb-3">
+        <label class="form-label">Logo</label>
+        <input type="file" name="logo" class="form-control">
+        <?php if ($settings && $settings['logo_url']): ?>
+            <img src="../<?php echo $settings['logo_url']; ?>" alt="Logo" class="mt-2" style="max-height:50px;">
+        <?php endif; ?>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Genişlik (px)</label>
+        <input type="number" name="logo_width" value="<?php echo $settings['logo_width']; ?>" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Yükseklik (px)</label>
+        <input type="number" name="logo_height" value="<?php echo $settings['logo_height']; ?>" class="form-control" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Kaydet</button>
+</form>
+<?php include 'partials/footer.php'; ?>

--- a/config.php
+++ b/config.php
@@ -1,0 +1,21 @@
+<?php
+$host = 'localhost';
+$db   = 'ajans_db';
+$user = 'root';
+$pass = '';
+$charset = 'utf8mb4';
+
+$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+try {
+    $pdo = new PDO($dsn, $user, $pass, $options);
+} catch (PDOException $e) {
+    throw new PDOException($e->getMessage(), (int)$e->getCode());
+}
+
+session_start();
+?>

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,16 @@
+body {
+    background: linear-gradient(180deg, #f5f5f5 0%, #ffffff 100%);
+    min-height: 100vh;
+}
+
+h2 {
+    font-weight: 600;
+}
+
+input:focus, button:focus {
+    box-shadow: 0 0 0 0.25rem rgba(13,110,253,.25);
+}
+
+.card {
+    border-radius: 1rem;
+}

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,0 +1,11 @@
+<?php
+require 'config.php';
+if (!isset($_SESSION['agency_id'])) {
+    header('Location: index.php');
+    exit;
+}
+?>
+<?php include 'partials/header.php'; ?>
+<h2>Hoş Geldiniz</h2>
+<p>Ajans kontrol paneline hoş geldiniz.</p>
+<?php include 'partials/footer.php'; ?>

--- a/database.sql
+++ b/database.sql
@@ -1,0 +1,49 @@
+CREATE TABLE IF NOT EXISTS `agencies` (
+  `id` int AUTO_INCREMENT PRIMARY KEY,
+  `agency_name` varchar(255) NOT NULL,
+  `contact_name` varchar(255) NOT NULL,
+  `phone` varchar(50) NOT NULL,
+  `email` varchar(255) NOT NULL UNIQUE,
+  `password_hash` varchar(255) NOT NULL,
+  `tax_number` varchar(100) NOT NULL,
+  `tax_office` varchar(100) NOT NULL,
+  `logo_url` varchar(255) DEFAULT NULL,
+  `status` enum('pending','active','rejected') DEFAULT 'pending',
+  `balance` decimal(10,2) DEFAULT 0,
+  `created_at` timestamp DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `admins` (
+  `id` int AUTO_INCREMENT PRIMARY KEY,
+  `name` varchar(255) NOT NULL,
+  `email` varchar(255) NOT NULL UNIQUE,
+  `password_hash` varchar(255) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `settings` (
+  `id` int AUTO_INCREMENT PRIMARY KEY,
+  `logo_url` varchar(255) DEFAULT NULL,
+  `logo_width` int DEFAULT 40,
+  `logo_height` int DEFAULT 40
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `orders` (
+  `id` int AUTO_INCREMENT PRIMARY KEY,
+  `agency_id` int NOT NULL,
+  `order_name` varchar(255) NOT NULL,
+  `total` decimal(10,2) NOT NULL,
+  `created_at` timestamp DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (`agency_id`) REFERENCES `agencies`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO admins (name, email, password_hash) VALUES
+  ('Admin', 'admin@example.com', '$2y$12$z.5OMDN2y9fWASP22PA5L.6m3WkhF7V45vLTitVsKz8lmGhhXxdE2');
+
+INSERT INTO agencies (agency_name, contact_name, phone, email, password_hash, tax_number, tax_office, logo_url, status, balance)
+VALUES ('Demo Ajans', 'Demo Yetkili', '5551234567', 'demo@agency.com', '$2y$12$cd/kEGcWeMBDGarQxueW4eQO1fg1MiAfG9yB1UqdQe91icOIIVXLO', '1234567890', 'Demo VD', NULL, 'active', 0);
+
+INSERT INTO orders (agency_id, order_name, total)
+VALUES (1, 'Demo Sipariş', 100.00);
+
+INSERT INTO settings (logo_url, logo_width, logo_height) VALUES ('uploads/logo.png', 40, 40);
+

--- a/index.php
+++ b/index.php
@@ -1,0 +1,46 @@
+<?php
+require 'config.php';
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = $_POST['email'] ?? '';
+    $password = $_POST['password'] ?? '';
+
+    $stmt = $pdo->prepare('SELECT * FROM agencies WHERE email = ? AND status = "active"');
+    $stmt->execute([$email]);
+    $agency = $stmt->fetch();
+    if ($agency && password_verify($password, $agency['password_hash'])) {
+        $_SESSION['agency_id'] = $agency['id'];
+        header('Location: dashboard.php');
+        exit;
+    } else {
+        $message = 'Geçersiz giriş bilgileri veya hesap onay bekliyor.';
+    }
+}
+?>
+<?php include 'partials/header.php'; ?>
+<div class="row justify-content-center">
+    <div class="col-md-5 col-lg-4">
+        <div class="card shadow-sm p-4">
+            <h2 class="mb-4 text-center">Ajans Girişi</h2>
+            <?php if ($message): ?>
+                <div class="alert alert-danger"><?php echo htmlspecialchars($message); ?></div>
+            <?php endif; ?>
+            <form method="post">
+                <div class="mb-3">
+                    <label class="form-label">E-posta</label>
+                    <input type="email" name="email" class="form-control" required>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Şifre</label>
+                    <input type="password" name="password" class="form-control" required>
+                </div>
+                <button type="submit" class="btn btn-primary w-100">Giriş</button>
+            </form>
+            <div class="mt-3 text-center">
+                <a href="register.php">Hesabınız yok mu? Kayıt olun</a>
+            </div>
+        </div>
+    </div>
+</div>
+<?php include 'partials/footer.php'; ?>

--- a/partials/footer.php
+++ b/partials/footer.php
@@ -1,0 +1,7 @@
+</div>
+<footer class="py-3 my-4 border-top text-center">
+    <p class="text-muted">&copy; 2024 Yazılım Ustası</p>
+</footer>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/partials/header.php
+++ b/partials/header.php
@@ -1,0 +1,27 @@
+<?php
+require_once __DIR__.'/../config.php';
+$s = $pdo->query('SELECT logo_url, logo_width, logo_height FROM settings LIMIT 1')->fetch();
+$logoUrl = $s['logo_url'] ?? 'uploads/logo.png';
+$logoW = $s['logo_width'] ?? 40;
+$logoH = $s['logo_height'] ?? 40;
+?>
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Yazılım Ustası</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/style.css">
+</head>
+<body style="font-family: 'Poppins', sans-serif;">
+<header class="bg-light py-3 mb-4 border-bottom">
+    <div class="container d-flex flex-wrap justify-content-center">
+        <a href="/" class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-dark text-decoration-none">
+            <img src="/<?php echo htmlspecialchars($logoUrl); ?>" alt="Logo" width="<?php echo (int)$logoW; ?>" height="<?php echo (int)$logoH; ?>" class="me-2">
+            <span class="fs-4">Yazılım Ustası</span>
+        </a>
+    </div>
+</header>
+<div class="container">

--- a/register.php
+++ b/register.php
@@ -1,0 +1,79 @@
+<?php
+require 'config.php';
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $agency_name = $_POST['agency_name'];
+    $contact_name = $_POST['contact_name'];
+    $phone = $_POST['phone'];
+    $email = $_POST['email'];
+    $password = $_POST['password'];
+    $tax_number = $_POST['tax_number'];
+    $tax_office = $_POST['tax_office'];
+    $logoPath = null;
+
+    if (!empty($_FILES['logo']['name'])) {
+        $targetDir = 'uploads/logos/';
+        if (!is_dir($targetDir)) {
+            mkdir($targetDir, 0777, true);
+        }
+        $fileName = uniqid() . '_' . basename($_FILES['logo']['name']);
+        $targetFile = $targetDir . $fileName;
+        if (move_uploaded_file($_FILES['logo']['tmp_name'], $targetFile)) {
+            $logoPath = $targetFile;
+        }
+    }
+
+    $hash = password_hash($password, PASSWORD_DEFAULT);
+    $stmt = $pdo->prepare('INSERT INTO agencies (agency_name, contact_name, phone, email, password_hash, tax_number, tax_office, logo_url, status, balance) VALUES (?, ?, ?, ?, ?, ?, ?, ?, "pending", 0)');
+    $stmt->execute([$agency_name, $contact_name, $phone, $email, $hash, $tax_number, $tax_office, $logoPath]);
+    $message = 'Kaydınız alınmıştır, yönetici onayından sonra giriş yapabilirsiniz.';
+}
+?>
+<?php include 'partials/header.php'; ?>
+<div class="row justify-content-center">
+    <div class="col-lg-6 col-md-8">
+        <div class="card shadow-sm p-4">
+            <h2 class="mb-4 text-center">Ajans Kaydı</h2>
+            <?php if ($message): ?>
+                <div class="alert alert-success"><?php echo htmlspecialchars($message); ?></div>
+            <?php endif; ?>
+            <form method="post" enctype="multipart/form-data">
+                <div class="mb-3">
+                    <label class="form-label">Ajans Adı</label>
+                    <input type="text" name="agency_name" class="form-control" required>
+                </div>
+            <div class="mb-3">
+                <label class="form-label">Yetkili Adı Soyadı</label>
+                <input type="text" name="contact_name" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Telefon</label>
+                <input type="text" name="phone" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">E-posta</label>
+                <input type="email" name="email" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Şifre</label>
+                <input type="password" name="password" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Vergi Numarası</label>
+                <input type="text" name="tax_number" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Vergi Dairesi</label>
+                <input type="text" name="tax_office" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Ajans Logosu</label>
+                <input type="file" name="logo" class="form-control">
+            </div>
+            <button type="submit" class="btn btn-primary w-100">Kaydol</button>
+        </form>
+        </div>
+    </div>
+</div>
+<?php include 'partials/footer.php'; ?>


### PR DESCRIPTION
## Summary
- allow balance collection updates directly from agency details

## Testing
- `php -l index.php`
- `php -l register.php`
- `php -l admin/agencies.php`
- `php -l admin/agency_details.php`
- `php -l admin/edit_agency.php`
- `php -l admin/index.php`
- `php -l admin/order_details.php`


------
https://chatgpt.com/codex/tasks/task_e_688b4236edec8333811f11dcc5c7e4f2